### PR TITLE
Added default --network for docker container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This API service recommends a k number of programs similar to another program  y
 `git clone git@github.com:kommandr/kommandr-ML.git`
 
 ### Build docker image
-`docker build -t api-recommender .`
+`docker build -t api-recommendr .`
 
 ### Run docker container
-`docker run --rm -it --name api-recommender -p 7070:7070 api-recommender`
+`docker run --rm -it --name api-recommendr -p 7070:7070 --network kommandrapi_default api-recommendr`
 
 ## Usage
 Examples


### PR DESCRIPTION
This PR modifies the name of the container following the coolest naming convention, recommender is now recommendr. This change also puts the container into the same network  "kommandrapi_default" that docker-compose creates for kommandr-api , making communication possible between api-node and api-recommendr.